### PR TITLE
Add script to populate epocdate from created_at

### DIFF
--- a/add_epocdate.py
+++ b/add_epocdate.py
@@ -1,0 +1,39 @@
+import os
+import pymysql
+from datetime import datetime
+
+MYSQL_USER = os.environ.get("MYSQLUSER", "root")
+MYSQL_PASSWORD = os.environ.get("MYSQLPW", "")
+MYSQL_DB = os.environ.get("MYSQLDB", "test")
+
+mysql_conn = pymysql.connect(
+    host="localhost",
+    user=MYSQL_USER,
+    password=MYSQL_PASSWORD,
+    database=MYSQL_DB,
+    charset="utf8mb4",
+    autocommit=True,
+)
+cur = mysql_conn.cursor()
+
+# Add epocdate column if it doesn't exist
+cur.execute("SHOW COLUMNS FROM treatments LIKE 'epocdate'")
+if not cur.fetchone():
+    cur.execute("ALTER TABLE treatments ADD COLUMN epocdate BIGINT DEFAULT NULL")
+
+# Fetch rows with created_at and mysqlid
+cur.execute("SELECT mysqlid, created_at FROM treatments")
+rows = cur.fetchall()
+
+for mysqlid, created_at in rows:
+    epoch_ms = None
+    if created_at:
+        try:
+            dt = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+            epoch_ms = int(dt.timestamp() * 1000)
+        except Exception:
+            epoch_ms = None
+    cur.execute("UPDATE treatments SET epocdate=%s WHERE mysqlid=%s", (epoch_ms, mysqlid))
+
+cur.close()
+mysql_conn.close()


### PR DESCRIPTION
## Summary
- add `add_epocdate.py` utility
- script adds an `epocdate` column to the `treatments` table and fills it from `created_at`

## Testing
- `python3 -m py_compile add_epocdate.py`

------
https://chatgpt.com/codex/tasks/task_e_6878b78cf8cc8329ac76c907faed6a97