### PR TITLE
Add PHP script for meal entry query

### DIFF
--- a/list_meal_entries.php
+++ b/list_meal_entries.php
@@ -1,0 +1,26 @@
+<?php
+$host = getenv('MYSQLHOST') ?: 'localhost';
+$user = getenv('MYSQLUSER') ?: 'root';
+$password = getenv('MYSQLPW') ?: '';
+$database = getenv('MYSQLDB') ?: 'test';
+
+$mysqli = new mysqli($host, $user, $password, $database);
+if ($mysqli->connect_errno) {
+    die("Failed to connect to MySQL: " . $mysqli->connect_error . PHP_EOL);
+}
+
+$mysqli->set_charset('utf8mb4');
+
+$query = "SELECT * FROM treatments WHERE eventType LIKE '%Meal Entry%'";
+$result = $mysqli->query($query);
+if (!$result) {
+    die("Query failed: " . $mysqli->error . PHP_EOL);
+}
+
+while ($row = $result->fetch_assoc()) {
+    echo json_encode($row) . PHP_EOL;
+}
+
+$result->free();
+$mysqli->close();
+?>


### PR DESCRIPTION
## Summary
- implement a PHP script to read MySQL connection info from env vars and query meal-related treatments

## Testing
- `php -l list_meal_entries.php`

------
https://chatgpt.com/codex/tasks/task_e_6878bc8622ac8329bb2494de46f89911