### PR TITLE
Use minute-level time dimension

### DIFF
--- a/create_star_schema.py
+++ b/create_star_schema.py
@@ -27,6 +27,7 @@ def create_dimension_tables():
             ts BIGINT NOT NULL,
             date DATE,
             hour INT,
+            minute INT,
             dow INT,
             month INT,
             year INT,
@@ -92,21 +93,22 @@ def create_fact_tables():
 
 
 def get_time_id(dt):
-    hour_dt = dt.replace(minute=0, second=0, microsecond=0)
-    ts_epoch = int(hour_dt.timestamp())
+    minute_dt = dt.replace(second=0, microsecond=0)
+    ts_epoch = int(minute_dt.timestamp())
     cur.execute("SELECT time_id FROM dim_time WHERE ts=%s", (ts_epoch,))
     res = cur.fetchone()
     if res:
         return res[0]
     cur.execute(
-        "INSERT INTO dim_time (ts, date, hour, dow, month, year) VALUES (%s,%s,%s,%s,%s,%s)",
+        "INSERT INTO dim_time (ts, date, hour, minute, dow, month, year) VALUES (%s,%s,%s,%s,%s,%s,%s)",
         (
             ts_epoch,
-            hour_dt.date(),
-            hour_dt.hour,
-            hour_dt.weekday(),
-            hour_dt.month,
-            hour_dt.year,
+            minute_dt.date(),
+            minute_dt.hour,
+            minute_dt.minute,
+            minute_dt.weekday(),
+            minute_dt.month,
+            minute_dt.year,
         ),
     )
     return cur.lastrowid

--- a/july7_overview.php
+++ b/july7_overview.php
@@ -33,7 +33,7 @@ function query_rows($mysqli, $sql, $params) {
 }
 
 // Meals
-$meals_sql = "SELECT dt.ts, dt.hour, fm.carbs, fm.protein, fm.fat, fm.classification AS meal_type
+$meals_sql = "SELECT dt.ts, dt.hour, dt.minute, fm.carbs, fm.protein, fm.fat, fm.classification AS meal_type
               FROM fact_meal fm
               JOIN dim_time dt ON fm.time_id = dt.time_id
               WHERE dt.date = ?
@@ -41,7 +41,7 @@ $meals_sql = "SELECT dt.ts, dt.hour, fm.carbs, fm.protein, fm.fat, fm.classifica
 $meals = query_rows($mysqli, $meals_sql, [$date]);
 
 // Insulin injections
-$insulin_sql = "SELECT dt.ts, dt.hour, dit.insulin_name, fi.units
+$insulin_sql = "SELECT dt.ts, dt.hour, dt.minute, dit.insulin_name, fi.units
                 FROM fact_insulin fi
                 JOIN dim_time dt ON fi.time_id = dt.time_id
                 LEFT JOIN dim_insulin_type dit ON fi.insulin_type_id = dit.insulin_type_id
@@ -50,7 +50,7 @@ $insulin_sql = "SELECT dt.ts, dt.hour, dit.insulin_name, fi.units
 $insulin = query_rows($mysqli, $insulin_sql, [$date]);
 
 // Glucose spikes
-$glucose_sql = "SELECT dt.ts, dt.hour, fg.sgv, fg.delta, fg.direction
+$glucose_sql = "SELECT dt.ts, dt.hour, dt.minute, fg.sgv, fg.delta, fg.direction
                 FROM fact_glucose fg
                 JOIN dim_time dt ON fg.time_id = dt.time_id
                 WHERE dt.date = ? AND fg.sgv >= ?

--- a/nillabg.sql
+++ b/nillabg.sql
@@ -44,6 +44,7 @@ CREATE TABLE `dim_time` (
   `ts` bigint(20) NOT NULL,
   `date` date DEFAULT NULL,
   `hour` int(11) DEFAULT NULL,
+  `minute` int(11) DEFAULT NULL,
   `dow` int(11) DEFAULT NULL,
   `month` int(11) DEFAULT NULL,
   `year` int(11) DEFAULT NULL


### PR DESCRIPTION
## Summary
- track minutes in the `dim_time` table
- generate minute-level keys when building the star schema
- surface `minute` field in sample PHP reports

## Testing
- `python3 -m py_compile create_star_schema.py classify_meals.py add_epocdate.py int_mongo_to_mysql.py mongo_to_mysql.py entries.py`
- `php -l july7_overview.php`


------
https://chatgpt.com/codex/tasks/task_e_6879102992008329be26cecd861916d7