### PR TITLE
Prevent dips from invalid CGM values

### DIFF
--- a/overview_graph.php
+++ b/overview_graph.php
@@ -63,7 +63,7 @@ $glucose_spikes = query_rows($mysqli, $glucose_spikes_sql, [$date, $threshold_mg
 $glucose_sql = "SELECT dt.ts, fg.sgv
                 FROM fact_glucose fg
                 JOIN dim_time dt ON fg.time_id = dt.time_id
-                WHERE dt.date = ?
+                WHERE dt.date = ? AND fg.sgv > 39 -- filter out sensor errors
                 ORDER BY dt.ts";
 $glucose = query_rows($mysqli, $glucose_sql, [$date]);
 


### PR DESCRIPTION
## Summary
- drop interpolation logic
- ignore implausible CGM values when creating the graph

## Testing
- `php -l overview_graph.php`


------
https://chatgpt.com/codex/tasks/task_e_687a1961a8c08329a58d3e610c4c6241