### PR TITLE
Restrict compute_metrics to bolus insulin

### DIFF
--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -69,10 +69,11 @@ query = """
     SELECT m.treatment_id, m.ts, m.carbs, fi.units, dt.hour
     FROM fact_meal m
     JOIN fact_insulin fi ON fi.ts BETWEEN m.ts - %s AND m.ts + %s
+    JOIN dim_insulin_type dit ON fi.insulin_type_id = dit.insulin_type_id
     JOIN dim_time dt ON m.time_id = dt.time_id
 """
 params = [TIME_WINDOW, TIME_WINDOW]
-conditions = []
+conditions = ["dit.insulin_class = 'bolus'"]
 if args.start:
     conditions.append("dt.date >= %s")
     params.append(args.start.isoformat())


### PR DESCRIPTION
## Summary
- adjust `compute_metrics.py` to ignore basal insulin
- default query now filters `insulin_class` to `bolus`

## Testing
- `python3 -m py_compile *.py`
- `python3 compute_metrics.py --help` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_687b5b0f875c8329b39437f56732acac