### PR TITLE
Enhance compute_metrics accuracy and flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Several utilities also use `MONGODBKEY` to connect to a Nightscout MongoDB insta
 
 ## Analysis tools
 
-- **`compute_metrics.py`** – compute average insulin sensitivity, carbohydrate ratio and absorption by time of day. Insulin sensitivity is reported in mmol/L per unit. Accepts optional `--start` and `--end` dates (`YYYY-MM-DD`).
+- **`compute_metrics.py`** – compute average insulin sensitivity, carbohydrate ratio and absorption by time of day. Insulin sensitivity is reported in mmol/L per unit. Supports optional `--start`/`--end` dates (`YYYY-MM-DD`) and windows for pairing insulin with meals or averaging glucose readings.
 - **`verify_time_consistency.py`** – check that timestamps in the star schema match the source tables.
 
 ## PHP helpers


### PR DESCRIPTION
## Summary
- add configurable windows and offsets for computing meal metrics
- average glucose over a configurable window
- ignore meals with correction boluses after eating
- convert carb absorption to mmol/L per g
- display median and standard deviation for each metric
- document new options in README

## Testing
- `python -m py_compile compute_metrics.py`
- `pip install pymysql`
- `python compute_metrics.py --help` *(fails: Can't connect to MySQL server)*

------
https://chatgpt.com/codex/tasks/task_e_687b842ce13c83298d309b5f520f7be3