### PR TITLE
Fix compute_metrics decimal handling

### DIFF
--- a/compute_metrics.py
+++ b/compute_metrics.py
@@ -130,7 +130,9 @@ def avg_glucose(
         (start, end),
     )
     row = cur.fetchone()
-    return row[0] if row and row[0] is not None else None
+    if row and row[0] is not None:
+        return float(row[0])
+    return None
 
 
 def correction_bolus_before(ts: int) -> bool:


### PR DESCRIPTION
## Summary
- ensure `avg_glucose` returns a float to avoid Decimal type errors

## Testing
- `python -m py_compile compute_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_687b87864a4c8329b6c9e52e4bc15772