### PR TITLE
Fix mysqli result buffering in overview_graph

### DIFF
--- a/overview_graph.php
+++ b/overview_graph.php
@@ -197,6 +197,7 @@ function compute_metrics(mysqli $mysqli): array {
     $stmt = $mysqli->prepare($sql);
     $stmt->bind_param('ii', $TIME_WINDOW, $TIME_WINDOW);
     $stmt->execute();
+    $stmt->store_result();
     $stmt->bind_result($tid, $ts, $carbs, $units, $hour);
 
     $stats = [];


### PR DESCRIPTION
## Summary
- avoid `Commands out of sync` error by storing results of the meal/insulin query

## Testing
- `php -l overview_graph.php`

------
https://chatgpt.com/codex/tasks/task_e_687bdd2e35e48329b843c19e843cf669